### PR TITLE
Adding some unit test cases - thanks Windsurf

### DIFF
--- a/pkg/proxy/namespace_round_tripper.go
+++ b/pkg/proxy/namespace_round_tripper.go
@@ -103,7 +103,7 @@ func NewCustomNamespaceRoundTripper(suffixNSMappingFile string) (*CustomNamespac
 
 	mappingManager, err := NewMappingManager(suffixNSMappingFile)
 	if err != nil {
-		return nil, fmt.Errorf("Error initializing mapping manager:", err)
+		return nil, fmt.Errorf("error initializing mapping manager: %v", err)
 	}
 
 	return &CustomNamespaceRoundTripper{
@@ -135,6 +135,7 @@ func (c *CustomNamespaceRoundTripper) RoundTrip(req *http.Request) (*http.Respon
 }
 
 // modifyNamespaceInPath replaces the namespace in the URL path with the configured one
+// it removes the tenant prefix and replaces the namespace with the configured one
 func (c *CustomNamespaceRoundTripper) modifyNamespaceInPath(path string) string {
 	parts := strings.Split(path, "/")
 	suffix := ""

--- a/pkg/proxy/namespace_round_tripper_test.go
+++ b/pkg/proxy/namespace_round_tripper_test.go
@@ -1,0 +1,81 @@
+package proxy
+
+import (
+	"testing"
+)
+
+func TestModifyNamespaceInPath(t *testing.T) {
+	// Create a temporary mapping file
+	mappings := map[string]string{
+		"tenant1": "namespace1",
+		"tenant2": "namespace2",
+	}
+
+	// Create a mapping manager with the test mappings
+	manager := &MappingManager{
+		mappings: mappings,
+	}
+
+	// Create a CustomNamespaceRoundTripper with the test mapping manager
+	tripper := &CustomNamespaceRoundTripper{
+		MappingManager:   manager,
+		DefaultNamespace: "default",
+	}
+
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "basic namespace replacement",
+			path:     "/tenant1/api/v1/namespaces/default/pods",
+			expected: "/api/v1/namespaces/namespace1/pods",
+		},
+		{
+			name:     "path without namespace",
+			path:     "/api/v1/pods",
+			expected: "/api/v1/pods",
+		},
+		{
+			name:     "path with unmapped tenant",
+			path:     "/unknown-tenant/api/v1/namespaces/default/pods",
+			expected: "/api/v1/namespaces/default/pods",
+		},
+		{
+			name:     "path with tenant but no namespace",
+			path:     "/tenant1/api?timeout=50s",
+			expected: "/api?timeout=50s",
+		},
+		{
+			name:     "path with tenant and a request to list namespaces",
+			path:     "/tenant1/api/v1/namespaces?limit=500",
+			expected: "/api/v1/namespaces?limit=500",
+		},
+		{
+			name:     "path with multiple namespaces segments",
+			path:     "/tenant2/api/v1/namespaces/default/pods/namespaces",
+			expected: "/api/v1/namespaces/namespace2/pods/namespaces",
+		},
+		{
+			name:     "path with api before tenant, no changes expected",
+			path:     "/api/tenant1/v1/namespaces/default/pods",
+			expected: "/api/tenant1/v1/namespaces/default/pods",
+		},
+		{
+			name:     "empty path",
+			path:     "",
+			expected: "/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tripper.modifyNamespaceInPath(tt.path)
+			if result != tt.expected {
+				t.Errorf("modifyNamespaceInPath(%q) = %q, want %q",
+					tt.path, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adding a unit test to check the path manipulation.

About 90% of the file namespace_round_tripper_test.go was created by Windsurf from Codeium and while it wasnt 100% accurate it is a huge time saver. This is just a draft and the `make test` 