### PR TITLE
 KAAP-618: Add region label selector for the specific kaapi objects

### DIFF
--- a/cmd/app/options/app.go
+++ b/cmd/app/options/app.go
@@ -39,8 +39,8 @@ func NewKubeOIDCProxyOptions(nfs *cliflag.NamedFlagSets) *KubeOIDCProxyOptions {
 func (k *KubeOIDCProxyOptions) AddFlags(fs *pflag.FlagSet) *KubeOIDCProxyOptions {
 	fs.StringVar(&k.SuffixNSMappingFile, "ns-mapping-file", "",
 		"(Alpha) A json file containing the suffix to namespace mapping. "+
-	"The suffix is typicall the last path in the server URL in kubeconfig."+
-		"for example https://kubernetes.default.svc:443/foobar/api/v1/... here the suffix is foobar")
+			"The suffix is typically the last path in the server URL in kubeconfig. "+
+			"For example, https://kubernetes.default.svc:443/foobar/api/v1/... here the suffix is foobar")
 
 	fs.BoolVar(&k.DisableImpersonation, "disable-impersonation", k.DisableImpersonation,
 		"(Alpha) Disable the impersonation of authenticated requests. All "+

--- a/pkg/proxy/namespace_round_tripper.go
+++ b/pkg/proxy/namespace_round_tripper.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 
@@ -14,6 +15,11 @@ import (
 )
 
 // MappingManager manages the JSON mapping file
+
+const (
+	labelSelectorPrefix = "pcd-kaapi.pf9.io/region="
+)
+
 type MappingManager struct {
 	mappings map[string]string
 	mutex    sync.RWMutex
@@ -103,7 +109,7 @@ func NewCustomNamespaceRoundTripper(suffixNSMappingFile string) (*CustomNamespac
 
 	mappingManager, err := NewMappingManager(suffixNSMappingFile)
 	if err != nil {
-		return nil, fmt.Errorf("Error initializing mapping manager:", err)
+		return nil, fmt.Errorf("error initializing mapping manager: %v", err)
 	}
 
 	return &CustomNamespaceRoundTripper{
@@ -129,6 +135,7 @@ func (c *CustomNamespaceRoundTripper) RoundTrip(req *http.Request) (*http.Respon
 	// Modify the namespace in the URL path
 
 	req.URL.Path = c.modifyNamespaceInPath(req.URL.Path)
+	c.addRegionLabelSelectorInPath(req)
 
 	// Forward the request to the next RoundTripper
 	return c.Transport.RoundTrip(req)
@@ -136,6 +143,7 @@ func (c *CustomNamespaceRoundTripper) RoundTrip(req *http.Request) (*http.Respon
 
 // modifyNamespaceInPath replaces the namespace in the URL path with the configured one
 func (c *CustomNamespaceRoundTripper) modifyNamespaceInPath(path string) string {
+
 	parts := strings.Split(path, "/")
 	suffix := ""
 	apiTokHit := false
@@ -156,6 +164,49 @@ func (c *CustomNamespaceRoundTripper) modifyNamespaceInPath(path string) string 
 		}
 	}
 	return joinPath(parts)
+}
+
+func (c *CustomNamespaceRoundTripper) addRegionLabelSelectorInPath(req *http.Request) {
+	parts := strings.Split(req.URL.Path, "/")
+
+	// Get region name
+	regionName := parts[1]
+
+	// remove region name from request
+	parts[1] = ""
+	req.URL.Path = joinPath(parts)
+
+	labelSelectorToBeAdded := []string{"byomachines", "byohosts", "hostedcontrolplanes", "openstackclusters", "machines", "machinedeployments", "clusters"}
+
+	// Add region label selector to the path only if the request comes for labelSelectorToBeAdded objects
+
+	/*
+		/apis/{kind}/{version}/namespaces/{namespace}/{object}
+	*/
+
+	for i, part := range parts {
+		if part == "namespaces" {
+			/*
+				if the request is for specific object with name, don't add label selector
+				eg: /apis/{kind}/{version}/namespaces/{namespace}/{object}/{object-name}
+				                              (i)       (i + 1)   (i + 2)   (i + 3)
+			*/
+			if len(parts) > i+3 && parts[i+3] != "" {
+				break
+			}
+
+			// check if object is in labelSelectorToBeAdded
+			if slices.Contains(labelSelectorToBeAdded, parts[i+2]) {
+				// add region label selector
+				query := req.URL.Query()
+
+				selector := labelSelectorPrefix + regionName
+				query.Set("labelSelector", selector)
+				req.URL.RawQuery = query.Encode()
+			}
+		}
+	}
+
 }
 
 func joinPath(parts []string) string {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -67,7 +67,7 @@ type Proxy struct {
 	noAuthClientTransport http.RoundTripper
 
 	//pf9
-	namespaceTransport   *CustomNamespaceRoundTripper
+	namespaceTransport *CustomNamespaceRoundTripper
 
 	config *Config
 


### PR DESCRIPTION
To get the Kaapi objects, UI / client will do a API request with below endpoint - 

`/oidc-proxy/service/regionone/apis/cluster.x-k8s.io/v1beta1/namespaces/du-on-devdp4-default-service/clusters`

`oidc-proxy` ingress will rewrite the target and will modify request to - 

`service/regionone/apis/cluster.x-k8s.io/v1beta1/namespaces/du-on-devdp4-default-service/clusters`

Logic in oidc-proxy will further modify this to - 

case 1: 
If request comes for specific object by object name or request came for object except these { "byomachines", "byohosts", "hostedcontrolplanes", "openstackclusters", "machines", "machinedeployments", "clusters" } labelSelector won't be added.

eg. 
input   -  `service/regionone/apis/cluster.x-k8s.io/v1beta1/namespaces/du-on-devdp4-default-service/clusters/clusterone`
output - `/apis/cluster.x-k8s.io/v1beta1/namespaces/du-on-devdp4-default-service/clusters/clusterone`

input -   `service/regionone/api/v1/namespaces/du-on-devdp4-default-service/configmaps`
output - `/api/v1/namespaces/du-on-devdp4-default-service/configmaps`

case 2: 
if request comes for any of { "byomachines", "byohosts", "hostedcontrolplanes", "openstackclusters", "machines", "machinedeployments", "clusters" } labelSelector will be added 

eg.
input    - `/oidc-proxy/service/regionone/apis/cluster.x-k8s.io/v1beta1/namespaces/du-on-devdp4-default-service/clusters`
output - `/apis/cluster.x-k8s.io/v1beta1/namespaces/du-on-devdp4-default-service/clusters?labelSelector?pcd-kaapi.pf9.io/region=regionone`


https://excalidraw.com/#json=9W8WY-CyzzhSUX5YNYHXL,rFPwOoeSNlipqL7yVupRgQ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces a new mechanism for region-specific routing by adding logic to inject region label selectors in API request paths. It improves help text clarity in the options module while enhancing the namespace round tripper with region selection functionality based on request type.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>