### PR TITLE
 kaap-735: Get all the clusters in the tenant namespace if API call has all-clusters-in-pf9-tenant-namespace at the end

### DIFF
--- a/pkg/proxy/namespace_round_tripper.go
+++ b/pkg/proxy/namespace_round_tripper.go
@@ -174,7 +174,6 @@ func (c *CustomNamespaceRoundTripper) addRegionLabelSelectorInPath(req *http.Req
 
 	// remove region name from request
 	parts[1] = ""
-	req.URL.Path = joinPath(parts)
 
 	labelSelectorToBeAdded := []string{"byomachines", "byohosts", "hostedcontrolplanes", "openstackclusters", "machines", "machinedeployments", "clusters"}
 
@@ -192,6 +191,10 @@ func (c *CustomNamespaceRoundTripper) addRegionLabelSelectorInPath(req *http.Req
 				                              (i)       (i + 1)   (i + 2)   (i + 3)
 			*/
 			if len(parts) > i+3 && parts[i+3] != "" {
+				// if the request is for all clusters in namespace, don't add label selector and remove all-clusters-in-pf9-tenant-namespace from path
+				if parts[i+2] == "clusters" && parts[i+3] == "all-clusters-in-pf9-tenant-namespace" {
+					parts[i+3] = ""
+				}
 				break
 			}
 
@@ -206,6 +209,7 @@ func (c *CustomNamespaceRoundTripper) addRegionLabelSelectorInPath(req *http.Req
 			}
 		}
 	}
+	req.URL.Path = joinPath(parts)
 
 }
 

--- a/pkg/proxy/namespace_round_tripper.go
+++ b/pkg/proxy/namespace_round_tripper.go
@@ -167,13 +167,13 @@ func (c *CustomNamespaceRoundTripper) modifyNamespaceInPath(path string) string 
 }
 
 func (c *CustomNamespaceRoundTripper) addRegionLabelSelectorInPath(req *http.Request) {
-	parts := strings.Split(req.URL.Path, "/")
+	partsOfPath := strings.Split(req.URL.Path, "/")
 
 	// Get region name
-	regionName := parts[1]
+	regionName := partsOfPath[1]
 
 	// remove region name from request
-	parts[1] = ""
+	partsOfPath[1] = ""
 
 	labelSelectorToBeAdded := []string{"byomachines", "byohosts", "hostedcontrolplanes", "openstackclusters", "machines", "machinedeployments", "clusters"}
 
@@ -183,23 +183,23 @@ func (c *CustomNamespaceRoundTripper) addRegionLabelSelectorInPath(req *http.Req
 		/apis/{kind}/{version}/namespaces/{namespace}/{object}
 	*/
 
-	for i, part := range parts {
-		if part == "namespaces" {
+	for i, partOfPath := range partsOfPath {
+		if partOfPath == "namespaces" {
 			/*
 				if the request is for specific object with name, don't add label selector
 				eg: /apis/{kind}/{version}/namespaces/{namespace}/{object}/{object-name}
 				                              (i)       (i + 1)   (i + 2)   (i + 3)
 			*/
-			if len(parts) > i+3 && parts[i+3] != "" {
+			if len(partsOfPath) > i+3 && partsOfPath[i+3] != "" {
 				// if the request is for all clusters in namespace, don't add label selector and remove all-clusters-in-pf9-tenant-namespace from path
-				if parts[i+2] == "clusters" && parts[i+3] == "all-clusters-in-pf9-tenant-namespace" {
-					parts[i+3] = ""
+				if partsOfPath[i+2] == "clusters" && partsOfPath[i+3] == "all-clusters-in-pf9-tenant-namespace" {
+					partsOfPath[i+3] = ""
 				}
 				break
 			}
 
 			// check if object is in labelSelectorToBeAdded
-			if slices.Contains(labelSelectorToBeAdded, parts[i+2]) {
+			if slices.Contains(labelSelectorToBeAdded, partsOfPath[i+2]) {
 				// add region label selector
 				query := req.URL.Query()
 
@@ -209,7 +209,7 @@ func (c *CustomNamespaceRoundTripper) addRegionLabelSelectorInPath(req *http.Req
 			}
 		}
 	}
-	req.URL.Path = joinPath(parts)
+	req.URL.Path = joinPath(partsOfPath)
 
 }
 


### PR DESCRIPTION
UI needs to get all the clusters in a namespace to do a validation so that it won't allow same name clusters to be created for that tenant.

Added a `all-clusters-in-pf9-tenant-namespace` at the end of the API call which will not add a label selector to filter cluster objects based on label. It will give all the clusters in a namespace irrespective of a region label.

UI will use this call only for validation purpose.

Example: 

`/oidc-proxy/service/regionone/apis/cluster.x-k8s.io/v1beta1/namespaces/du-on-devdp4-default-service/clusters`

Oidc-proxy will change this to - 
`/apis/cluster.x-k8s.io/v1beta1/namespaces/du-on-devdp4-default-service/clusters?labelSelector=pcd-kaapi.pf9.io/region=regionone`

response will have cluster objects having label of regionone.

-----
whereas

`/oidc-proxy/service/regionone/apis/cluster.x-k8s.io/v1beta1/namespaces/du-on-devdp4-default-service/clusters/all-clusters-in-pf9-tenant-namespace`


Oidc-proxy will change this to - 
`apis/cluster.x-k8s.io/v1beta1/namespaces/du-on-devdp4-default-service/clusters`

response will have all the clusters in du-on-devdp4-default-service namespace irrespective of region label. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR fixes namespace round tripper issues by updating logic with clearer variable naming, removing redundant URL path assignment, and adding refined conditional checks to detect and remove special tokens. These changes ensure API calls targeting all clusters properly bypass label selectors, improving request routing accuracy for tenant namespace validations and enhancing robustness in namespace-based API calls.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>