### PR TITLE
fix: pin trivy to 0.69.3 (CVE-2026-33634)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -111,7 +111,7 @@ jobs:
           wget -qO- https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo tee /etc/apt/trusted.gpg.d/trivy.asc
           echo "deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list
           sudo apt update
-          sudo apt install -y trivy jq
+          sudo apt install -y trivy=0.69.3 jq
 
       - name: Sanitize branch name
         run: echo "SAFE_REF_NAME=${GITHUB_REF_NAME//\//-}" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

Pins `trivy` apt package to version `0.69.3` in `.github/workflows/security-scan.yml`.

Unpinned `apt install -y trivy` was vulnerable to CVE-2026-33634
(supply chain risk via mutable package version).

## References

- CVE: https://www.cve.org/CVERecord?id=CVE-2026-33634
- Safe version per security guidance: `trivy=0.69.3`

## Test plan

- [ ] CI `trivy_scan` job passes with pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)